### PR TITLE
Fix 22.2 input parameters settings

### DIFF
--- a/src/ansys/fluent/parametric/parameters.py
+++ b/src/ansys/fluent/parametric/parameters.py
@@ -121,14 +121,16 @@ class InputParameters(MutableMapping):
     >>> inp['parameter-1'] = '0.5 [m/s]'
     >>> inp['parameter-1']
     '0.5 [m/s]'
-    >>> inp['parameter-1'] = '40 [cm/s]'  # only in Fluent 23.1
-    >>> inp['parameter-1']
-    '0.4 [m/s]'
     >>> inp.get_unit_label('parameter-1')
     'm/s'
-    >>> inp['parameter-1'] = 0.5
+    >>> inp['parameter-1'] = '40 [cm/s]'
     >>> inp['parameter-1']
-    '0.5 [m/s]'
+    '40 [cm/s]'
+    >>> inp.get_unit_label('parameter-1')
+    'cm/s'
+    >>> inp['parameter-1'] = 50
+    >>> inp['parameter-1']
+    '50 [cm/s]'
 
     """
 

--- a/tests/test_input_output_parameters.py
+++ b/tests/test_input_output_parameters.py
@@ -1,6 +1,5 @@
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
-import pytest
 
 from ansys.fluent.parametric.parameters import InputParameters, OutputParameters
 
@@ -11,20 +10,25 @@ def test_input_output_parameters():
     session.solver.root.file.read(file_name=case_filepath, file_type="case")
     inp = InputParameters(session)
     assert len(inp) == 1
-    assert inp["inlet_pressure"] == "91192.5 [atm]"
+    assert inp["inlet_pressure"] == "0.9 [atm]"
     assert inp.get_unit_label("inlet_pressure") == "atm"
 
-    inp["inlet_pressure"] = "90000 [atm]"
-    assert inp["inlet_pressure"] == "90000.0 [atm]"
+    inp["inlet_pressure"] = "0.91 [atm]"
+    assert inp["inlet_pressure"] == "0.91 [atm]"
     assert inp.get_unit_label("inlet_pressure") == "atm"
 
-    inp["inlet_pressure"] = 90005
-    assert inp["inlet_pressure"] == "90005.0 [atm]"
+    inp["inlet_pressure"] = 0.92
+    assert inp["inlet_pressure"] == "0.92 [atm]"
     assert inp.get_unit_label("inlet_pressure") == "atm"
 
-    with pytest.raises(RuntimeError):
-        inp["inlet_pressure"] = "90010 [Pa]"
+    inp["inlet_pressure"] = "90000 [Pa]"
+    assert inp["inlet_pressure"] == "90000 [Pa]"
+    assert inp.get_unit_label("inlet_pressure") == "Pa"
+
+    inp["inlet_pressure"] = "90001 [Pa]"
+    assert inp["inlet_pressure"] == "90001 [Pa]"
+    assert inp.get_unit_label("inlet_pressure") == "Pa"
 
     outp = OutputParameters(session)
     assert len(outp) == 1
-    assert outp["inlet_pressure"] == "0.0 [kg/s]"
+    assert outp["mass-outlet-op"] == "0.0 [kg/s]"

--- a/tests/test_input_output_parameters.py
+++ b/tests/test_input_output_parameters.py
@@ -25,7 +25,7 @@ def test_input_output_parameters():
     assert inp["inlet_pressure"] == "90000 [Pa]"
     assert inp.get_unit_label("inlet_pressure") == "Pa"
 
-    inp["inlet_pressure"] = "90001 [Pa]"
+    inp["inlet_pressure"] = 90001
     assert inp["inlet_pressure"] == "90001 [Pa]"
     assert inp.get_unit_label("inlet_pressure") == "Pa"
 

--- a/tests/test_input_output_parameters.py
+++ b/tests/test_input_output_parameters.py
@@ -2,10 +2,10 @@ import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 import pytest
 
-from ansys.fluent.parametric.parameters import InputParameters
+from ansys.fluent.parametric.parameters import InputParameters, OutputParameters
 
 
-def test_input_parameters():
+def test_input_output_parameters():
     case_filepath = examples.download_file("nozzle-2D-WB.cas.h5", "pyfluent/optislang")
     session = pyfluent.launch_fluent(version="2d")
     session.solver.root.file.read(file_name=case_filepath, file_type="case")
@@ -24,3 +24,7 @@ def test_input_parameters():
 
     with pytest.raises(RuntimeError):
         inp["inlet_pressure"] = "90010 [Pa]"
+
+    outp = OutputParameters(session)
+    assert len(outp) == 1
+    assert outp["inlet_pressure"] == "0.0 [kg/s]"

--- a/tests/test_input_parameters.py
+++ b/tests/test_input_parameters.py
@@ -1,0 +1,26 @@
+import ansys.fluent.core as pyfluent
+from ansys.fluent.core import examples
+import pytest
+
+from ansys.fluent.parametric.parameters import InputParameters
+
+
+def test_input_parameters():
+    case_filepath = examples.download_file("nozzle-2D-WB.cas.h5", "pyfluent/optislang")
+    session = pyfluent.launch_fluent(version="2d")
+    session.solver.root.file.read(file_name=case_filepath, file_type="case")
+    inp = InputParameters(session)
+    assert len(inp) == 1
+    assert inp["inlet_pressure"] == "91192.5 [atm]"
+    assert inp.get_unit_label("inlet_pressure") == "atm"
+
+    inp["inlet_pressure"] = "90000 [atm]"
+    assert inp["inlet_pressure"] == "90000.0 [atm]"
+    assert inp.get_unit_label("inlet_pressure") == "atm"
+
+    inp["inlet_pressure"] = 90005
+    assert inp["inlet_pressure"] == "90005.0 [atm]"
+    assert inp.get_unit_label("inlet_pressure") == "atm"
+
+    with pytest.raises(RuntimeError):
+        inp["inlet_pressure"] = "90010 [Pa]"


### PR DESCRIPTION
Please see the unitest for the implemented behaviour.

For 23.1, it will use the Fluent's settings API as backend.
For 22.2, it will use the Fluent's named-expressions structure as backend on which the 23.1 settings API is based on.