### PR TITLE
Create a release only when a version tag is pushed.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -203,7 +203,7 @@ jobs:
 
   release:
     name: Release
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is to avoid automatically creating releases when iteration-ends tags (which have a format like `date-0805`) are pushed. Releases will be created only when tags like `vX.Y.Z` are pushed.