### PR TITLE
Implementing dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/requirements" # Location of package manifests
+    insecure-external-code-execution: allow
+    schedule:
+      interval: "daily"
+    labels:
+      - "Maintenance"
+      - "Dependencies"
+    ignore:
+      - dependency-name: "vtk"
+      - dependency-name: "grpcio"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I just realized as well that in https://github.com/pyansys/pyfluent-parametric you do not have dependabot implemented. This is a good way of keeping up-to-date our requirements. And following https://github.com/pyansys/pyfluent/pull/703 it is also easy to keep up with GH Action  updates (they are also important to keep up to date).

If for any reason you do not want to set up dependabot in this repository just close this PR =)