### PR TITLE
Fix for empty scheme list

### DIFF
--- a/src/ansys/fluent/parametric/parameters.py
+++ b/src/ansys/fluent/parametric/parameters.py
@@ -63,9 +63,10 @@ class _InputParametersSchemeImpl(MutableMapping):
         self._unit_label_getter = unit_label_getter
 
     def _get_parameter_names(self):
-        return self._scheme_eval(
+        parameter_names = self._scheme_eval(
             "(send (get expressions-package named-expression-manager) get-names)"
         )
+        return parameter_names if parameter_names else []
 
     def __setitem__(self, name: str, value: V) -> None:
         if name not in self._get_parameter_names():
@@ -163,7 +164,7 @@ class InputParameters(MutableMapping):
             Unit label of the Fluent input parameter.
 
         """
-        value = self[name]
+        value = str(self[name])
         value_split = value.split(maxsplit=1)
         if len(value_split) == 1:
             return ""
@@ -269,9 +270,10 @@ class OutputParameters(Mapping):
         self._session = session
 
     def _get_parameter_names(self):
-        return self._session.scheme_eval.scheme_eval(
+        parameter_names = self._session.scheme_eval.scheme_eval(
             "(map (lambda (p) (send p get-name)) (get-all-output-parameters))"
         )
+        return parameter_names if parameter_names else []
 
     def _get_unit_label(self, name: str) -> str:
         if name not in self._get_parameter_names():

--- a/src/ansys/fluent/parametric/parameters.py
+++ b/src/ansys/fluent/parametric/parameters.py
@@ -63,13 +63,12 @@ class _InputParametersSchemeImpl(MutableMapping):
         self._unit_label_getter = unit_label_getter
 
     def _get_parameter_names(self):
-        parameter_names = (
+        return (
             self._scheme_eval(
                 "(send (get expressions-package named-expression-manager) get-names)"
             )
             or []
         )
-        return parameter_names if parameter_names else []
 
     def __setitem__(self, name: str, value: V) -> None:
         if name not in self._get_parameter_names():
@@ -273,13 +272,12 @@ class OutputParameters(Mapping):
         self._session = session
 
     def _get_parameter_names(self):
-        parameter_names = (
+        return (
             self._session.scheme_eval.scheme_eval(
                 "(map (lambda (p) (send p get-name)) (get-all-output-parameters))"
             )
             or []
         )
-        return parameter_names if parameter_names else []
 
     def _get_unit_label(self, name: str) -> str:
         if name not in self._get_parameter_names():


### PR DESCRIPTION
Scheme's empty list (which is its null type) is mapped to Python None. Adding extra check to build the output list based on scheme function call.