### PR TITLE
Zip HTML documentation before uploading the in github CI run.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -155,11 +155,16 @@ jobs:
           DOCS_CNAME: fluentparametric.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
+      - name: Zip HTML Documentation before upload
+        run: |
+          sudo apt install zip -y
+          zip -r doc.zip doc/_build/html
+
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ matrix.image-tag }}
-          path: doc/_build/html
+          path: doc.zip
           retention-days: 7
 
       - name: Deploy


### PR DESCRIPTION
Documentation html files have been zipped before uploading for the github CI run. This saves a lot of time by not requiring to upload large size files.