### PR TITLE
Feat/gh-pages deployment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -139,7 +139,7 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          DOCS_CNAME: parametric.fluent.docs.pyansys.com
+          DOCUMENTATION_CNAME: 'parametric.fluent.docs.pyansys.com'
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Upload HTML Documentation

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Deploy
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pyansys/actions/doc-deploy-stable@v2
+        uses: pyansys/actions/doc-deploy-stable@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -87,6 +87,7 @@ jobs:
     runs-on: [self-hosted, pyfluent]
     env:
       DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+      DOCUMENTATION_CNAME: 'parametric.fluent.docs.pyansys.com'
     steps:
       - uses: actions/checkout@v3
 
@@ -139,7 +140,6 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          DOCUMENTATION_CNAME: 'parametric.fluent.docs.pyansys.com'
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Upload HTML Documentation

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -139,30 +139,23 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          DOCS_CNAME: fluentparametric.docs.pyansys.com
+          DOCS_CNAME: parametric.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
+          path: doc/_build/html
           retention-days: 7
 
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: pyansys/actions/doc-deploy-stable@v2
         with:
-          repository-name: pyansys/pyfluent-parametric-docs
-          token: ${{ steps.get_workflow_token.outputs.token  }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
 
   build:

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -65,7 +65,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: matrix.image-tag == 'v23.1.0'
         uses: pyansys/actions/doc-deploy-dev@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -54,7 +54,6 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          DOCS_CNAME: dev.parametric.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Upload HTML Documentation

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Deploy
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pyansys/actions/doc-deploy-stable@v2
+        uses: pyansys/actions/doc-deploy-dev@v3
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -5,6 +5,10 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
+env:
+  DOCUMENTATION_CNAME: 'parametric.fluent.docs.pyansys.com'
+  DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+
 jobs:
   nightly_docs_build:
     runs-on: ubuntu-20.04
@@ -50,15 +54,21 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          DOCS_CNAME: dev.fluentparametric.docs.pyansys.com
+          DOCS_CNAME: dev.parametric.fluent.docs.pyansys.com
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
-      - name: Deploy
-        if: matrix.image-tag == 'v22.2.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload HTML Documentation
+        uses: actions/upload-artifact@v3
         with:
-          repository-name: pyansys/pyfluent-parametric-dev-docs
-          token: ${{ steps.get_workflow_token.outputs.token }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: doc/_build/html
+
+          retention-days: 7
+
+      - name: Deploy
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: pyansys/actions/doc-deploy-stable@v2
+        with:
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -5,7 +5,7 @@ import platform
 import subprocess
 
 import ansys.fluent.core as pyfluent
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black
+from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black, get_version_match
 import numpy as np
 import pyvista
 from sphinx_gallery.sorting import FileNameSortKey
@@ -35,6 +35,9 @@ pyfluent.BUILDING_GALLERY = True
 project = "ansys-fluent-parametric"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
+
+# Canonical Name of the Webpage
+cname = os.getenv("DOCUMENTATION_CNAME", "parametric.fluent.docs.pyansys.com")
 
 # The short X.Y version
 release = version = __version__
@@ -174,6 +177,11 @@ html_short_title = html_title = "PyFluent-Parametric"
 html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black
 html_theme_options = {
+    "switcher": {
+        "json_url": f"https://{cname}/release/versions.json",
+        "version_match": get_version_match(__version__),
+    },
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "github_url": "https://github.com/pyansys/pyfluent-parametric",
     "show_prev_next": False,
     "show_breadcrumbs": True,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -5,7 +5,7 @@ import platform
 import subprocess
 
 import ansys.fluent.core as pyfluent
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black, get_version_match
+from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 import numpy as np
 import pyvista
 from sphinx_gallery.sorting import FileNameSortKey

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,7 +1,7 @@
 Sphinx==5.1.0
 jupyter_sphinx==0.4.0
 numpydoc==1.4.0
-ansys-sphinx-theme==0.7.0
+ansys-sphinx-theme==0.8.0
 pypandoc==1.8.1
 pytest-sphinx==0.4.0
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Updated the conf.py and workflow files to push the built documentation to the gh-pages branch and enable the multi-version feature.

Afterwards, will require configuring the CNAME outside of GitHub to deploy and host the docs.