### PR TITLE
Edit support email address and Contribute section heading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ release `documentation <https://fluentparametric.docs.pyansys.com>`_.
 
 On the `PyFluent-Parametric Issues <https://github.com/pyansys/pyfluent-parametric/issues>`_,
 you can create issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_.
+the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ release `documentation <https://fluentparametric.docs.pyansys.com>`_.
 
 On the `PyFluent-Parametric Issues <https://github.com/pyansys/pyfluent-parametric/issues>`_,
 you can create issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,8 +1,8 @@
 .. _ref_contributing:
 
-============
-Contributing
-============
+==========
+Contribute
+==========
 Overall guidance on contributing to a PyAnsys library appears in
 `Contributing <https://dev.docs.pyansys.com/how-to/contributing.html>`_
 in the *PyAnsys Developer's Guide*. Ensure that you are thoroughly familiar with

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -32,7 +32,7 @@ released versions.
 
 On the `PyFluent-Parametric Issues <https://github.com/pyansys/pyfluent-parametric/issues>`_,
 you can create issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 License
 -------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,6 +25,11 @@ In addition to installation and usage information, the PyFluent-Visualization
 documentation provides :ref:`ref_index_api`, :ref:`ref_example_gallery`, and :ref:`ref_contributing`
 sections.
 
+In the upper right corner of the documentation's title bar, there is an option
+for switching from viewing the documentation for the latest stable release
+to viewing the documentation for the development version or previously
+released versions.
+
 On the `PyFluent-Parametric Issues <https://github.com/pyansys/pyfluent-parametric/issues>`_,
 you can create issues to submit questions, report bugs, and request new features. To reach
 the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,7 +27,7 @@ sections.
 
 On the `PyFluent-Parametric Issues <https://github.com/pyansys/pyfluent-parametric/issues>`_,
 you can create issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_.
+the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 License
 -------


### PR DESCRIPTION
Change the email address for support and shorten the title for the "Contribute" section to match other PyAnsys libraries.